### PR TITLE
Fix possible typo SMTPPASSWORD to SMTP_PASSWORD

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,7 +8,7 @@ postconf -e "relayhost = [${SMTP_HOST}]:587" \
 "smtp_tls_security_level = encrypt" \
 "smtp_tls_note_starttls_offer = yes"
 
-echo "[${SMTP_HOST}]:587 ${SMTP_USERNAME}:${SMTPPASSWORD}" > /etc/postfix/sasl_passwd
+echo "[${SMTP_HOST}]:587 ${SMTP_USERNAME}:${SMTP_PASSWORD}" > /etc/postfix/sasl_passwd
 
 postmap hash:/etc/postfix/sasl_passwd
 


### PR DESCRIPTION
Changing the variable name to match naming convention and the documentation.