### PR TITLE
Copy  container resolv.conf to postfix chroot

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -15,6 +15,7 @@ postmap hash:/etc/postfix/sasl_passwd
 ## Allow for overriding every config
 for e in ${!POSTFIX_*} ; do postconf -e "${e:8}=${!e}" ; done
 
+cp /etc/resolv.conf /var/spool/postfix/etc/resolv.conf
 rm -f /var/spool/postfix/pid/master.pid
 
 exec "$@"


### PR DESCRIPTION
It might just be me, but the container was not able to resolve the SES SMTP endpoint URI. This changed ended up working for me based on:

- https://stackoverflow.com/questions/49675940/postfix-smtp-dns-lookup-a-record-fails
- https://bugs.launchpad.net/ubuntu/+source/postfix/+bug/1519331